### PR TITLE
Add Options JSON for configuration

### DIFF
--- a/views/index.php
+++ b/views/index.php
@@ -97,7 +97,7 @@
                 </div>
 
                 <div class="uk-margin">
-                    <label class="uk-text-small uk-text-bold">@lang('Children')</label> <span class="uk-text-muted uk-text-small">@lang('e.g. Sections')</pan>
+                    <label class="uk-text-small uk-text-bold">@lang('Children')</label> <span class="uk-text-muted uk-text-small">@lang('e.g. Sections')</span>
                     <field-boolean class="uk-display-block uk-margin-small-top" bind="component.meta.children" label="{false}"></field-boolean>
                 </div>
 
@@ -118,6 +118,11 @@
             <div class="uk-margin-top">
                 <label class="uk-text-small uk-text-bold">@lang('Fields')</label>
                 <cp-fieldsmanager class="uk-display-block uk-margin-small-top" bind="component.meta.fields" localize="{false}"></cp-fieldsmanager>
+            </div>
+
+            <div class="uk-margin">
+                <label class="uk-text-small uk-text-bold">@lang('Options JSON')</label>
+                <field-object cls="uk-width-1-1" bind="component.meta.options" rows="6" allowtabs="2"></field-object>
             </div>
 
             <div class="uk-margin-large-top">


### PR DESCRIPTION
Adding ability to configure JSON options for LayoutComponents in the same way as on fields in Collections. 

Ideally it should be in an accordion or modal to keep the form clean but i didn't have time to figure out how, UIkit elements don't seem to work out of the box. Happy to work on that if you point me in the right direction or to documentation. 

The use-case i'm working on is to use [CustomComponents](https://github.com/pauloamgomes/Cockpit-CustomComponents) to specify which components can be added to a LayoutComponent which accepts children. This is needed because not all components are compatible with all other components in the front-end app (Nuxt). 

![image](https://user-images.githubusercontent.com/15634297/56730386-178c7080-6782-11e9-828f-ef672b0dcb2c.png)
